### PR TITLE
Release 2.11.08

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.11.06" %}
+{% set version = "2.11.08" %}
 
 {% set VC_VERSION = os.environ.get("VC_VERSION", "")|string %}
 
@@ -9,7 +9,7 @@ package:
 source:
   fn: nasm-{{ version }}.tar.gz
   url: http://www.nasm.us/pub/nasm/releasebuilds/{{ version }}/nasm-{{ version }}.tar.gz
-  sha256: 64daa8bb04c8e3383c6b1cc23d26d8af030456ac442bda2fdd32cd56326139b9
+  sha256: ef6d1af3a4ede67f5eb8d4e76c72003e2b1eae3fd1b721f79f0c0abea00dadc0
 
 build:
   number: 0


### PR DESCRIPTION
```
\S{cl-2.11.08} Version 2.11.08

\b Fix section length computation in \c{bin} backend which leaded in incorrect
   relocation records.

\b Add a warning for numeric preprocessor definitions passed via command
   line which might have unexpected results otherwise.

\b Add ability to specify a module name record in \c{rdoff} linker with
   \c{-mn} option.

\b Increase label length capacity up to 256 bytes in \c{rdoff} backend for
   FreePascal sake, which tends to generate very long labels for procedures.

\b Fix segmentation failure when rip addressing is used in \c{macho64} backend.

\b Fix access on out of memory when handling strings with a single
   grave. We have sixed similar problem in previous release but not
   all cases were covered.

\b Fix NULL dereference in disassembled on \c{BND} instruction.
```