### PR TITLE
Release 2.12.02

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,16 +10,6 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      VC_VERSION: 9
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      VC_VERSION: 9
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
       VC_VERSION: 14
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,5 @@
 matrix:
   - []
-  - [[VC_VERSION, 9], [CONDA_PY, 27]]
   - [[VC_VERSION, 14], [CONDA_PY, 36]]
 
 travis:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.11.08" %}
+{% set version = "2.12.02" %}
 
 {% set VC_VERSION = os.environ.get("VC_VERSION", "")|string %}
 
@@ -9,7 +9,7 @@ package:
 source:
   fn: nasm-{{ version }}.tar.gz
   url: http://www.nasm.us/pub/nasm/releasebuilds/{{ version }}/nasm-{{ version }}.tar.gz
-  sha256: ef6d1af3a4ede67f5eb8d4e76c72003e2b1eae3fd1b721f79f0c0abea00dadc0
+  sha256: d1b465dd1f83a90c0940d99b816df653759ed665428debf16771407bde2a80fc
 
 build:
   number: 0


### PR DESCRIPTION
```
\S{cl-2.12.02} Version 2.12.02

\b Fix preprocessor errors, especially \c{%error} and \c{%warning},
   inside \c{%if} statements.

\b Fix relative relocations in 32-bit Mach-O.

\b More Codeview debug format fixes.

\b If the MASM PTR keyword is encountered, issue a warning.  This is
   much more likely to indicate a MASM-ism encountered in NASM than it
   is a valid label.  This warning can be suppressed with \c{-w-ptr},
   the \c{[warning]} directive (see \k{opt-w}) or by the macro
   definition \c{%idefine ptr %??}.

\b When an error or a warning comes from the expansion of a multi-line
   macro, display the file and line numbers for the expanded macros.
   Macros defined with \c{.nolist} do not get displayed.

\b Add macros \c{ilog2fw()} and \c{ilog2cw()} to the \c{ifunc} macro
   package.  See \k{ilog2}.


\S{cl-2.12.01} Version 2.12.01

\b Portability fixes for some platforms.

\b Fix error when not specifying a list file.

\b Correct the handling of macro-local labels in the Codeview
   debugging format.

\b Add \c{CLZERO}, \c{MONITORX} and \c{MWAITX} instructions.


\S{cl-2.12} Version 2.12

\b Major fixes to the \c{macho} backend (\k{machofmt}); earlier versions
   would produce invalid symbols and relocations on a regular basis.

\b Support for thread-local storage in Mach-O.

\b Support for arbitrary sections in Mach-O.

\b Fix wrong negative size treated as a big positive value passed into
   backend causing NASM to crash.

\b Fix handling of zero-extending unsigned relocations, we have been printing
   wrong message and forgot to assign segment with predefined value before
   passing it into output format.

\b Fix potential write of oversized (with size greater than allowed in
   output format) relative relocations.

\b Portability fixes for building NASM with LLVM compiler.

\b Add support of Codeview version 8 (\c{cv8}) debug format for
   \c{win32} and \c{win64} formats in the \c{COFF} backend,
   see \k{codeview}.

\b Allow 64-bit outputs in 16/32-bit only backends.  Unsigned 64-bit
   relocations are zero-extended from 32-bits with a warning
   (suppressible via \c{-w-zext-reloc}); signed 64-bit relocations are
   an error.

\b Line numbers in list files now correspond to the lines in the source
   files, instead of simply being sequential.

\b There is now an official 64-bit (x64 a.k.a. x86-64) build for Windows.


\S{cl-2.11.09} Version 2.11.09

\b Fix potential stack overwrite in \c{macho32} backend.

\b Fix relocation records in \c{macho64} backend.

\b Fix symbol lookup computation in \c{macho64} backend.

\b Adjust \c{.symtab} and \c{.rela.text} sections alignments to 8 bytes
   in \c{elf64} backed.

\b Fix section length computation in \c{bin} backend which leaded in incorrect
   relocation records.
```