### PR TITLE
Release 2.13.02

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.02" %}
+{% set version = "2.13.02" %}
 
 {% set VC_VERSION = os.environ.get("VC_VERSION", "")|string %}
 
@@ -9,7 +9,7 @@ package:
 source:
   fn: nasm-{{ version }}.tar.gz
   url: http://www.nasm.us/pub/nasm/releasebuilds/{{ version }}/nasm-{{ version }}.tar.gz
-  sha256: d1b465dd1f83a90c0940d99b816df653759ed665428debf16771407bde2a80fc
+  sha256: 4749fd76a8a26dc7d8871bc97cc2c16cfa0c933f984a13128e94f464f417531a
 
 build:
   number: 0


### PR DESCRIPTION
```
\S{cl-2.13.02} Version 2.13.02

\b Fix false positive in testing of numeric overflows.

\b Fix generation of \c{PEXTRW} instruction.

\b Fix \c{smartalign} package which could trigger an error during
   optimization if the alignment code expanded too much due to
   optimization of the previous code.

\b Fix a case where negative value in \c{TIMES} directive causes
   panic instead of an error.

\b Always finalize \c{.debug_abbrev} section with a null in
   \c{dwarf} output format.

\b Support \c{debug} flag in section attributes for \c{macho}
   output format.  See \k{machosect}.

\b Support up to 16 characters in section names for \c{macho}
   output format.

\b Fix missing update of global \c{BITS} setting if \c{SECTION}
   directive specified a bit size using output format-specific
   extensions (e.g. \c{USE32} for the \c{obj} output format.)

\b Fix the incorrect generation of VEX-encoded instruction when static
   mode decorators are specified on scalar instructions, losing the
   decorators as they require EVEX encoding.

\b Option \c{-MW} to quote dependency outputs according to Watcom
   Make conventions instead of POSIX Make conventions.  See \k{opt-MW}.

\b The \c{obj} output format now contains embedded dependency file
   information, unless disabled with \c{%pragma obj nodepend}.  See
   \k{objdepend}.

\b Fix generation of dependency lists.

\b Fix a number of null pointer reference and memory allocation errors.

\b Always generate symbol-relative relocations for the \c{macho64}
   output format; at least some versions of the XCode/LLVM linker fails
   for section-relative relocations.

\S{cl-2.13.01} Version 2.13.01

\b Fix incorrect output for some types of \c{FAR} or \c{SEG}
   references in the \c{obj} output format, and possibly other 16-bit
   output formats.

\b Fix the address in the list file for an instruction containing a
   \c{TIMES} directive.

\b Fix error with \c{TIMES} used together with an instruction which
   can vary in size, e.g. \c{JMP}.

\b Fix breakage on some uses of the \c{DZ} pseudo-op.

\S{cl-2.13} Version 2.13

\b Support the official forms of the \c{UD0} and \c{UD1} instructions.

\b Allow self-segment-relative expressions in immediates and
   displacements, even when combined with an external or otherwise
   out-of-segment special symbol, e.g.:

\c      extern foo
\c      mov eax,[foo - $ + ebx]               ; Now legal

\b Handle a 64-bit origin in NDISASM.

\b NASM can now generate sparse output files for relevant output
   formats, if the underlying operating system supports them.

\b The \c{macho} object format now supports the \c{subsections_via_symbols}
   and \c{no_dead_strip} directives, see \k{macho-ssvs}.

\b The \c{macho} object format now supports the \c{no_dead_strip},
  \c{live_support} and \c{strip_static_syms} section flags, see
  \k{machosect}.

\b The \c{macho} object format now supports the \c{dwarf} debugging
  format, as required by newer toolchains.

\b All warnings can now be suppressed if desired; warnings not
   otherwise part of any warning class are now considered its own
   warning class called \c{other} (e.g. \c{-w-other}).  Furthermore,
   warning-as-error can now be controlled on a per warning class
   basis, using the syntax \c{-w+error=}\e{warning-class} and its
   equivalent for all other warning control options.  See \k{opt-w}
   for the command-line options and warning classes and
   \k{asmdir-warning} for the \c{[WARNING]} directive.

\b Fix a number of bugs related to AVX-512 decorators.

\b Significant improvements to building NASM with Microsoft Visual
   Studio via \c{Mkfiles/msvc.mak}.  It is now possible to build the
   full Windows installer binary as long as the necessary
   prerequisites are installed; see \c{Mkfiles/README}

\b To build NASM with custom modifications (table changes) or from the
   git tree now requires Perl 5.8 at the very minimum, quite possibly
   a higher version (Perl 5.24.1 tested.)  There is no requirement to
   have Perl on your system at all if all you want to do is build
   unmodified NASM from source archives.

\b Fix the \c{\{z\}} decorator on AVX-512 \c{VMOVDQ*} instructions.

\b Add new warnings for certain dangerous constructs which never ought
   to have been allowed.  In particular, the \c{RESB} family of
   instructions should have been taking a critical expression all
   along.

\b Fix the EVEX (AVX-512) versions of the \c{VPBROADCAST}, \c{VPEXTR},
   and \c{VPINSR} instructions.

\b Support contracted forms of additional instructions.  As a general
   rule, if an instruction has a non-destructive source immediately
   after a destination register that isn't used as an input, NASM
   supports omitting that source register, using the destination
   register as that value.  This among other things makes it easier to
   convert SSE code to the equivalent AVX code:

\c      addps xmm1,xmm0                       ; SSE instruction
\c      vaddps ymm1,ymm1,ymm0                 ; AVX official long form
\c      vaddps ymm1,ymm0                      ; AVX contracted form

\b Fix Codeview malformed compiler version record.

\b Add the \c{CLWB} and \c{PCOMMIT} instructions.  Note that the
   \c{PCOMMIT} instruction has been deprecated and will never be
   included in a shipping product; it is included for completeness
   only.

\b Add the \c{%pragma} preprocessor directive for soft-error directives.

\b Add the \c{RDPID} instruction.
```