### PR TITLE
Drop unused `VC_VERSION` Jinja variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set version = "2.13.02" %}
 
-{% set VC_VERSION = os.environ.get("VC_VERSION", "")|string %}
-
 package:
   name: nasm
   version: {{ version }}


### PR DESCRIPTION
The need for this was removed a while back, but this apparently got missed. Has no real effect. Though the code should be dropped anyways.

xref: https://github.com/conda-forge/nasm-feedstock/pull/5